### PR TITLE
Prevent docker-compose from being installed by brew

### DIFF
--- a/setup-box.yml
+++ b/setup-box.yml
@@ -24,7 +24,6 @@
       brew_packages_to_install:
         - node
         - macvim
-        - docker-compose
         - jq
         - couchdb
         - hub


### PR DESCRIPTION
Since binary already comes with Docker for Mac
